### PR TITLE
doc: 添加了一些vscode的调试说明

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -11,6 +11,7 @@
             "protocol": "inspector",
             "port": 8080,
             "sourceMaps": true,
+            // you can comment out "remoteRoot" config or replace it's ${workspaceRoot} with ${workspaceFolder} when you use a new visual studio code
             "remoteRoot": "${workspaceRoot}Content/JavaScript"
         }
     ]

--- a/README.md
+++ b/README.md
@@ -23,3 +23,5 @@
 * 编译，在vscode上“Terminal -> Run Build Task”选tsc watch，修改代码后会自动编译。
 
 * PerfTest.ts编辑器下在老版本v8以及quickjs后端不可用
+
+* 若采用较新版本的vscode进行调试，发现无法命中断点，则尝试将本demo目录根目录下".vscode"目录中的"launch.json"中的"remoteRoot"配置项的"${workspaceRoot}"修改为"${workspaceFolder}"，或者直接去除"remoteRoot"配置项。


### PR DESCRIPTION
新版的vscode废弃了${workspaceRoot}改为推荐使用${workspaceFolder}变量。现在这个版本会无法命中断点的，
![image](https://github.com/chexiongsheng/puerts_unreal_demo/assets/36122477/86989773-c894-48c8-816d-577424597f68)
直接注释掉这个配置也是可以的